### PR TITLE
Remove unnecessary noisy debug log message

### DIFF
--- a/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/file/FileWatcher.java
+++ b/ch.acanda.eclipse.pmd.core/src/ch/acanda/eclipse/pmd/file/FileWatcher.java
@@ -128,7 +128,6 @@ public final class FileWatcher {
             if (!OVERFLOW.equals(event.kind())) {
                 final String filename = event.context().toString();
                 final Path file = directory.resolve(filename);
-                PMDPlugin.getDefault().info(event.kind() + ": " + file);
                 final List<FileChangedListener> fileListeners = listeners.get(file);
                 if (fileListeners != null) {
                     for (final FileChangedListener listener : fileListeners) {


### PR DESCRIPTION
FileWatcher watches the the parent directory of the ruleset and writes out debug messages for each event.

This clutters the log:
```
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\bin
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\bin
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\README.txt
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\README.txt
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\pmd6_ruleset.xml
!MESSAGE Invalidating cache for myproject
!MESSAGE ENTRY_MODIFY: C:\foo\bar\myproject\pmd6_ruleset.xml
!MESSAGE Invalidating cache for myproject
!MESSAGE RuleSetsCache: loading rule sets for project myproject
```

The ENTRY_MODIFY debug messages are not really necessary.